### PR TITLE
Ticket stock checker

### DIFF
--- a/app/api/clear-checkout-session/route.ts
+++ b/app/api/clear-checkout-session/route.ts
@@ -1,0 +1,12 @@
+import { stripe } from '@/app/utils/private/stripe';
+import { getActiveCheckoutSession } from '@/app/utils/private/supabase';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+    const { userId } = await req.json()
+    const activeCheckoutSession = await getActiveCheckoutSession(userId)
+    if(!activeCheckoutSession) { return new NextResponse("No active checkout session", { status: 400 }) }
+    await stripe.checkout.sessions.expire(activeCheckoutSession.stripe_session_id)
+    console.log('session cancelled')
+    return new NextResponse('OK', {status: 200})
+}

--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -1,7 +1,8 @@
 import { CURRENT_CON_ID } from '@/app/utils/constants';
+import { days, getDayValue } from '@/app/utils/day-mapping';
 import { stripe } from '@/app/utils/private/stripe';
-import { supabase } from '@/app/utils/private/supabase';
-import { getTicketStock } from '@/app/utils/public/stripe';
+import { getTicketAvailability, getActiveCheckoutSession, isUserRegistered, removeTicketFromDays, startUserCheckout, supabase } from '@/app/utils/private/supabase';
+import { NextResponse } from 'next/server';
 
 const regStartTime = Number(process.env.NEXT_PUBLIC_REG_START_TIME)
 const regEndTime = Number(process.env.NEXT_PUBLIC_REG_END_TIME)
@@ -14,41 +15,44 @@ export async function POST(req: Request) {
     if (userId !== overrideUserId && Date.now() < regStartTime) { return new Response(new Blob(), { status: 401, statusText: "Reg is not open yet" }) }
     if (Date.now() > regEndTime) { return new Response(new Blob(), { status: 401, statusText: "Reg is now closed" }) }
 
-    // We shouldn't let a user pay again if they're already registered, that'd be complicated
-    const { data: registration, error } = await supabase
-        .from('registrations')
-        .select('*')
-        .eq('user_id', userId)
-        .eq('convention_id', CURRENT_CON_ID)
-        .maybeSingle()
-
-    const couponId = await getActiveCouponId();
-
-    const ticketStock = await getTicketStock();
-
-    const isSoldOut = (day: string) => {
-        const sold = parseInt(ticketStock[`tickets_sold_${day}`]);
-        const capacity = parseInt(ticketStock[`venue_capacity_${day}`]);
-
-        return sold >= capacity;
+    // Only let users who are fully registered buy a ticket
+    const { data: registration, error: regError } = await isUserRegistered(userId)
+    if (regError) {
+        return new NextResponse(`Error finding user with id ${userId}`, { status: 500 })
+    } else if (registration) {
+        return new NextResponse(`User with id ${userId} is already registered`, { status: 401 })
     }
 
-    const saturdaySoldOut = isSoldOut("sat")
-    const sundaySoldOut = isSoldOut("sun")
-    const weekendSoldOut = saturdaySoldOut || sundaySoldOut
+    // Don't let the user start another checkout session, otherwise an attacker could quickly drain the ticket stock
+    const userCheckingOut = await getActiveCheckoutSession(userId) != null
+    if (userCheckingOut) {
+        return new NextResponse(`User with id ${userId} is already in a checkout session`, { status: 401 })
+    }
+    let ticketStock;
+    try {
+        ticketStock = new Set(await getTicketAvailability());
+    } catch (error: any) {
+        return NextResponse.json(
+            { error: error.message },
+            { status: 500 }
+        );
+    }
 
+    const fridaySoldOut = !ticketStock.has(days.friday)
+    const saturdaySoldOut = !ticketStock.has(days.saturday)
+    const sundaySoldOut = !ticketStock.has(days.sunday)
+    const weekendSoldOut = fridaySoldOut || saturdaySoldOut || sundaySoldOut
+    const dayIndex = getDayValue(selectedDay.toLowerCase())
     const selectedDaySoldOut =
-        (selectedDay === "Saturday" && saturdaySoldOut) ||
-        (selectedDay === "Sunday" && sundaySoldOut) ||
-        (selectedDay === "Weekend" && weekendSoldOut)
+        selectedDay === "Full-Event"
+            ? weekendSoldOut
+            : !ticketStock.has(dayIndex)
 
     if (selectedDaySoldOut) {
-        return new Response(new Blob(), { status: 410, statusText: "Error. This ticket is no longer in stock" })
-    } else if (error) {
-        return new Response(new Blob(), { status: 500, statusText: "Error finding user with id " + userId })
-    } else if (registration) {
-        return new Response(new Blob(), { status: 401, statusText: "User is already registered" })
+    console.log(ticketStock, selectedDay)
+        return new NextResponse(`Sorry, tickets for ${selectedDay} have sold out and are no longer in stock`, { status: 410 })
     }
+
     try {
         const session = await stripe.checkout.sessions.create({
             line_items: [
@@ -58,9 +62,7 @@ export async function POST(req: Request) {
                 }
             ],
             mode: 'payment',
-            discounts: [{
-                coupon: couponId,
-            }],
+            discounts: [],
             success_url: `${req.headers.get('origin')}/reg#confirmation`,
             cancel_url: `${req.headers.get('origin')}/dashboard#payment-cancelled`,
             metadata: { userId },
@@ -75,20 +77,10 @@ export async function POST(req: Request) {
             expires_at: Math.floor(Date.now() / 1000) + 1820, // checkout session expires ~30 minutes after creation
         })
 
-        return Response.json({ sessionId: session.id })
+        await startUserCheckout(userId, session.id)
+        await removeTicketFromDays(selectedDay === 'Full-Event' ? null : dayIndex)
+        return NextResponse.json({ sessionId: session.id })
     } catch {
-        return new Response(new Blob(), { status: 500, statusText: "Stripe checkout error" })
+        return new NextResponse("Stripe checkout error", { status: 500 })
     }
-}
-
-async function getActiveCouponId() {
-    const coupons = await stripe.coupons.list();
-
-    const earlyBird = coupons.data.find((c) => c.name === 'Early Bird Discount (Until Oct 4th)');
-    if (earlyBird?.valid)
-        return earlyBird.id;
-
-    const standard = coupons.data.find((c) => c.name === 'Standard Fare (Until Jan 4th)');
-    if (standard?.valid)
-        return standard.id;
 }

--- a/app/api/get-selected-product/route.ts
+++ b/app/api/get-selected-product/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: Request) {
             query: `active: \'true\' AND metadata[\'day\']: ${SqlString.escape(day)} AND metadata[\'tier\']: ${SqlString.escape(tier)}`,
             limit: 1
         })
-
+        
         return NextResponse.json(result.data[0]);
     } catch (e) {
         console.error("Can't find product", e);

--- a/app/api/get-ticket-stock/route.ts
+++ b/app/api/get-ticket-stock/route.ts
@@ -1,15 +1,17 @@
-import { stripe } from "@/app/utils/private/stripe";
 import { NextResponse } from "next/server";
-
-const controlProductId = process.env.STRIPE_CONTROL_PRODUCT_ID
+import { getTicketAvailability } from '@/app/utils/private/supabase';
 
 export async function GET() {
-    if (!controlProductId) { throw new Error('Missing Stripe Control Product ID environment variable, ensure STRIPE_CONTROL_PRODUCT_ID is set for this machine') }
+    let tickets;
     try {
-        const controlProduct = await stripe.products.retrieve(controlProductId)
-        return NextResponse.json(controlProduct.metadata)
-    } catch (e) {
-        console.error("Cannot get ticket information")
-        return new NextResponse("Cannot get ticket information", { status: 500 });
+        tickets = await getTicketAvailability();
+    } catch (error: any) {
+        return NextResponse.json(
+            { error: error.message },
+            { status: 500 }
+        );
     }
+
+
+    return NextResponse.json(tickets);
 }

--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { stripe, stripeWebhookSecret } from '@/app/utils/private/stripe';
 import { addTicketToDays, clearUserCheckout, supabase } from '@/app/utils/private/supabase';
 import { getDayValue } from '@/app/utils/day-mapping';
+import { CURRENT_CON_ID } from '@/app/utils/constants';
 
 export async function POST(req: Request) {
     const rawBody = Buffer.from(await req.arrayBuffer())
@@ -39,7 +40,7 @@ export async function POST(req: Request) {
 
             const { error } = await supabase
                 .from('registrations')
-                .upsert({ user_id: userId, payment_status: 'paid', convention_id: 1, ticket_type: ticketType })
+                .upsert({ user_id: userId, payment_status: 'paid', convention_id: CURRENT_CON_ID, ticket_type: ticketType })
 
             if (error) {
                 console.error('Supabase error when updating paid status', error);

--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -1,8 +1,9 @@
 import Stripe from 'stripe';
 
 import { NextResponse } from 'next/server';
-import { stripe, stripeWebhookSecret, updateTicketStock } from '@/app/utils/private/stripe';
-import { supabase } from '@/app/utils/private/supabase';
+import { stripe, stripeWebhookSecret } from '@/app/utils/private/stripe';
+import { addTicketToDays, clearUserCheckout, supabase } from '@/app/utils/private/supabase';
+import { getDayValue } from '@/app/utils/day-mapping';
 
 export async function POST(req: Request) {
     const rawBody = Buffer.from(await req.arrayBuffer())
@@ -11,7 +12,6 @@ export async function POST(req: Request) {
     // Verify request is legit
     const signature = req.headers.get('stripe-signature')
     if (!signature) { return new NextResponse('Not allowed', { status: 400 }) }
-
     try {
         event = stripe.webhooks.constructEvent(rawBody, signature, stripeWebhookSecret)
     } catch {
@@ -19,32 +19,69 @@ export async function POST(req: Request) {
         return new NextResponse('Not allowed', { status: 400 })
     }
 
-    console.log(event)
+    if (!isCheckoutSessionEvent(event)) {
+        return new NextResponse('Ignored', { status: 200 });
+    }
+
+    const userId = event.data.object.metadata?.['userId']
+
+    if (!userId) {
+        console.error(`Received ${event.type} with no user id. Cannot update supabase`)
+        return new NextResponse('Missing UserID from Metadata!', { status: 500 })
+    }
+
     switch (event.type) {
         case 'checkout.session.async_payment_succeeded':
         case 'checkout.session.completed':
-            const userId = event.data.object.metadata?.['userId']
-
-            if (!userId) {
-                console.error(`Received ${event.type} with no user id. Cannot update supabase`)
-                return new NextResponse('Missing UserID from Metadata!', { status: 500 })
-            }
+            await clearUserCheckout(userId)
 
             const lineItems = await stripe.checkout.sessions.listLineItems(event.data.object.id);
             const ticketType = lineItems.data[0]?.description || 'Unknown';
-            await updateTicketStock(ticketType);
-            
+
             const { error } = await supabase
-            .from('registrations')
-            .upsert({ user_id: userId, payment_status: 'paid', convention_id: 1, ticket_type: ticketType })
-            
+                .from('registrations')
+                .upsert({ user_id: userId, payment_status: 'paid', convention_id: 1, ticket_type: ticketType })
+
             if (error) {
                 console.error('Supabase error when updating paid status', error);
                 return new NextResponse('Error updating registration', { status: 500 });
             }
 
             break;
-    }
 
+        case 'checkout.session.async_payment_failed':
+        case 'checkout.session.expired':
+            await clearUserCheckout(userId)
+            const cancellationLineItems = await stripe.checkout.sessions.listLineItems(
+                event.data.object.id,
+                {
+                    expand: ['data.price.product'],
+                }
+            );
+
+            const product = cancellationLineItems.data[0].price?.product;
+
+            if (typeof product !== 'object' || product === null || product.deleted) {
+                return new NextResponse('Product information not found for cancellation', { status: 500 })
+            }
+
+            const ticketDay = product.metadata.day;
+            await addTicketToDays(ticketDay === 'full-event' ? null : getDayValue(ticketDay))
+            break;
+    }
     return new NextResponse('OK', { status: 200 })
+}
+
+
+function isCheckoutSessionEvent(
+    event: Stripe.Event
+): event is Stripe.Event & {
+    data: { object: Stripe.Checkout.Session }
+} {
+    return (
+        event.type === 'checkout.session.async_payment_succeeded' ||
+        event.type === 'checkout.session.completed' ||
+        event.type === 'checkout.session.async_payment_failed' ||
+        event.type === 'checkout.session.expired'
+    );
 }

--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -30,11 +30,10 @@ export async function POST(req: Request) {
         return new NextResponse('Missing UserID from Metadata!', { status: 500 })
     }
 
+    await clearUserCheckout(userId)
     switch (event.type) {
         case 'checkout.session.async_payment_succeeded':
         case 'checkout.session.completed':
-            await clearUserCheckout(userId)
-
             const lineItems = await stripe.checkout.sessions.listLineItems(event.data.object.id);
             const ticketType = lineItems.data[0]?.description || 'Unknown';
 
@@ -51,7 +50,6 @@ export async function POST(req: Request) {
 
         case 'checkout.session.async_payment_failed':
         case 'checkout.session.expired':
-            await clearUserCheckout(userId)
             const cancellationLineItems = await stripe.checkout.sessions.listLineItems(
                 event.data.object.id,
                 {

--- a/app/app-view.tsx
+++ b/app/app-view.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { Inter, Sora } from "next/font/google";
 import NavBar from "./components/nav-bar";
+import { useEffect } from "react";
 
 const interSans = Inter({
     variable: "--font-inter",
@@ -36,7 +37,7 @@ export function AppView({
 
             <div className="flex h-[100%] flex-col items-center justify-contet-space-between p-8 pt-0 pb-20 gap-16 font-[family-name:var(--font-inter)]">
                 <main className="flex flex-col flex-grow gap-[32px] items-center">
-                    <div className="w-[20rem] sm:w-[25rem] flex justify-center mr-auto ml-auto mt-6 relative mb-[-28%] sm:mb-[-26%] min-h-45">
+                    <div className="w-[20rem] sm:w-[25rem] flex justify-center mr-auto ml-auto mt-6 relative mb-[-89px] sm:mb-[-103px] min-h-45">
                         <img
                             src="roots.webp"
                             alt="Logo"

--- a/app/app-view.tsx
+++ b/app/app-view.tsx
@@ -50,8 +50,9 @@ export function AppView({
                     </fieldset>
                 </main>
 
-                <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-                    Copyright Ainmhícon 2026
+                <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center text-center">
+                    Copyright Ainmhicon 2026<br/><br/>
+
                     Ainmhícon, Company Limited by Guarantee, Company No. 793565
                 </footer>
             </div>

--- a/app/components/loading.tsx
+++ b/app/components/loading.tsx
@@ -1,5 +1,5 @@
-export default function Loading() {
+export default function Loading({className = ''}: {className?: string}) {
     return (
-        <div className='w-full flex justify-center grow'><span className="loading loading-ring loading-lg"></span></div>
+        <div className={`w-full flex justify-center grow$ ${className}`}><span className="loading loading-ring loading-lg"></span></div>
     )
 }

--- a/app/dashboard/view.tsx
+++ b/app/dashboard/view.tsx
@@ -118,7 +118,7 @@ export function DashboardView({ user, attendee, registration, logout, regStartTi
     const startRegComponent = (<>
         {!sufficientDetailToPurchaseTicket && <p className='my-[8px]'>Before you register for a ticket you'll need to provide some additional information, please update your details.</p>}
         {(regEndTime - time <= (1000 * 60 * 60 * 24 * 7 /* 1 week */)) && regTimerEndComponent}
-        <Link href='/reg' className={`btn rounded-md bg-base-100 text-base-content ${!sufficientDetailToPurchaseTicket && 'btn-disabled'}`}>Register for Ainmhícon 2027</Link>
+        <Link href='/reg' className={`btn btn-secondary rounded-md ${!sufficientDetailToPurchaseTicket && 'btn-disabled'}`}>Register for Ainmhícon 2027</Link>
     </>)
     const regClosedComponent = (
         <>

--- a/app/dashboard/view.tsx
+++ b/app/dashboard/view.tsx
@@ -8,6 +8,7 @@ import Telegram from "./social-logos/telegram";
 import { verifyAge } from "../utils/age-verification";
 import { User } from "@supabase/supabase-js";
 const minimumConventionAge = Number(process.env.NEXT_PUBLIC_CON_MIN_AGE)
+const supportEmail = process.env.NEXT_PUBLIC_SUPPORT_EMAIL
 
 interface DashboardViewProps {
     user: User | null
@@ -187,7 +188,7 @@ export function DashboardView({ user, attendee, registration, logout, regStartTi
                     </li>
                 </ul>
             </>}
-            {registration && <p className='my-[8px]'>If you wish to cancel or upgrade your ticket please email: <a href='reg@ainmhicon.ie' className='underline text-info'>reg@ainmhicon.ie</a></p>}
+            {registration && <p className='my-[8px]'>If you wish to cancel or upgrade your ticket please email: <a href={`mailto:${supportEmail}`} className='underline text-info'>{supportEmail}</a></p>}
 
             <Link href='/user-details' className='btn mt-8 rounded-md btn-secondary'>Update my details</Link>
             {registration && <Link href='/hotel-booking' className='btn btn-secondary rounded-md'>Booking the Venue Hotel</Link>}

--- a/app/dashboard/view.tsx
+++ b/app/dashboard/view.tsx
@@ -6,9 +6,11 @@ import Bluesky from "./social-logos/bluesky";
 import Instagram from "./social-logos/instagram";
 import Telegram from "./social-logos/telegram";
 import { verifyAge } from "../utils/age-verification";
+import { User } from "@supabase/supabase-js";
 const minimumConventionAge = Number(process.env.NEXT_PUBLIC_CON_MIN_AGE)
 
 interface DashboardViewProps {
+    user: User | null
     attendee: Attendee | null
     registration: Registration | null
     logout: () => void
@@ -16,7 +18,7 @@ interface DashboardViewProps {
     regEndTime: number
 }
 
-export function DashboardView({ attendee, registration, logout, regStartTime, regEndTime }: DashboardViewProps) {
+export function DashboardView({ user, attendee, registration, logout, regStartTime, regEndTime }: DashboardViewProps) {
     const [time, setTime] = useState(Date.now());
     const [showCancelled, setShowCancelled] = useState(false);
     const [showAgeError, setShowAgeError] = useState(false)
@@ -33,6 +35,11 @@ export function DashboardView({ attendee, registration, logout, regStartTime, re
             setShowCancelled(true);
             // Remove hash to avoid repeat message
             history.replaceState(null, "", window.location.pathname);
+            fetch('/api/clear-checkout-session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ userId: user?.id })
+            })
         }
     }, []);
 
@@ -150,17 +157,17 @@ export function DashboardView({ attendee, registration, logout, regStartTime, re
 
     return (
         <>
-            <div role={showCancelled ? "alert" : 'presentation'} className={`alert alert-error alert-vertical sm:alert-horizontal fixed bottom-4 left-1/2 transform -translate-x-1/2 transition-all duration-500 ease-in-out ${showCancelled ? 'translate-y-0 opacity-100' : 'translate-y-20 opacity-0 pointer-events-none'}`}>
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-base-300 h-6 w-6 shrink-0">
+            <div role={showCancelled ? "alert" : 'presentation'} className={`alert alert-error alert-vertical sm:alert-horizontal fixed bottom-4 left-1/2 transform -translate-x-1/2 transition-all duration-500 ease-in-out text-[#fff] ${showCancelled ? 'translate-y-0 opacity-100' : 'translate-y-20 opacity-0 pointer-events-none'}`}>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current h-6 w-6 shrink-0">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>
                 <div>
                     <h3 className="font-bold">Payment cancelled</h3>
                     <div className="text-xs">Sorry, your payment did not complete. You have not been charged. Please try again later.</div>
                 </div>
-                <button className="btn btn-sm btn-secondary" onClick={() => setShowCancelled(false)}>Okay</button>
+                <button className="btn btn-sm btn-secondary bg-white text-error border-0 rounded-3xl" onClick={() => setShowCancelled(false)}>Okay</button>
             </div>
-            <h2 className='font-[family-name:var(--font-sora)] text-xl'>
+            <h2 className='font-[family-name:var(--font-sora)] text-xl text-center'>
                 Welcome back, {attendee.nickname}!
             </h2>
             {!registration && <p className='my-[8px]'>Thanks for signing up, this is your user dashboard. From here you can register for our upcoming conventions</p>}

--- a/app/dashboard/view.tsx
+++ b/app/dashboard/view.tsx
@@ -170,16 +170,27 @@ export function DashboardView({ user, attendee, registration, logout, regStartTi
             <h2 className='font-[family-name:var(--font-sora)] text-xl text-center'>
                 Welcome back, {attendee.nickname}!
             </h2>
-            {!registration && <p className='my-[8px]'>Thanks for signing up, this is your user dashboard. From here you can register for our upcoming conventions</p>}
+            {!registration && <p className='my-2'>Thanks for signing up, this is your user dashboard. From here you can register for our upcoming conventions</p>}
             {registration && <>
-                <p className='my-[8px]'>You are registered for Ainmhícon 2027!</p>
-                <p className='text-center font-bold'>{registration.ticket_type} <br /> {getAttendingDate(registration.ticket_type)}</p>
-                <p className='my-[8px]'>Your badge number is <b>#{registration.badge_id}</b>, we're looking forward to seeing you soon!</p>
+                <div className="divider"/>
+                <p className='text-center font-bold text-md'>{registration.ticket_type} <br /> {getAttendingDate(registration.ticket_type)}</p>
+                <p className='mt-2 my-0 text-center'>Registration Number</p>
+                <h3 className='text-2xl my-0 font-bold text-center'>{registration.badge_id}</h3>
+                <div className="divider"/>
+                <p>When you arrive at the convention please report to ConOps! You will need:</p>
+                <ul className="p-2">
+                    <li  className="before:content-['✓'] before:mr-2">
+                        Your registration number
+                    </li>
+                    <li className="before:content-['✓'] before:mr-2">
+                        <a className='underline text-info' href='https://ainmhicon.ie/code-of-conduct#id'>Valid ID</a> showing your date of birth
+                    </li>
+                </ul>
             </>}
-            {registration && <p className='my-[8px]'><em>If you wish to cancel or upgrade your ticket please email:</em> <a href='reg@ainmhicon.ie' className='underline text-info'>reg@ainmhicon.ie</a></p>}
+            {registration && <p className='my-[8px]'>If you wish to cancel or upgrade your ticket please email: <a href='reg@ainmhicon.ie' className='underline text-info'>reg@ainmhicon.ie</a></p>}
 
-            <Link href='/user-details' className='btn mt-8 rounded-md bg-base-100 text-base-content'>Update my details</Link>
-            {registration && <Link href='/hotel-booking' className='btn'>Booking the Venue Hotel</Link>}
+            <Link href='/user-details' className='btn mt-8 rounded-md btn-secondary'>Update my details</Link>
+            {registration && <Link href='/hotel-booking' className='btn btn-secondary rounded-md'>Booking the Venue Hotel</Link>}
 
             {regFlowStart}
             {showAgeError && <p className='mt-8 font-bold'>Attendees must be at least {minimumConventionAge} years old on the first day of the convention. Our records indicate you do not meet this requirement, so registration is not allowed. Please verify your Date of Birth on the <a href='/user-details' className='underline'>user details page</a></p>}

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,7 +50,8 @@
   --color-base-content: #f7eabb;
   --color-primary: #e85442;
   --color-primary-content: #f7eabb;
-  --color-secondary: oklch(57% 0.245 27.325);
+
+  --color-secondary: #a1ab5a;
   --color-secondary-content: oklch(97% 0.013 17.38);
   --color-accent: #f7eabb;
   --color-accent-content: #9c7850;
@@ -63,7 +64,7 @@
   --color-warning: oklch(82% 0.189 84.429);
   --color-warning-content: oklch(27% 0.077 45.635);
   --color-error: oklch(70% 0.191 22.216);
-  --color-error-content: oklch(25% 0.092 26.042);
+  --color-error-content: #fff;
   --radius-selector: 0.5rem;
   --radius-box: 2rem;
   --size-selector: 0.25rem;

--- a/app/hotel-booking/page.tsx
+++ b/app/hotel-booking/page.tsx
@@ -13,11 +13,11 @@ export default function HotelBooking() {
     return (
         <>
             <p>To book a room in our venue hotel, please book directly on their website:</p>
-            <p>For more information about staying at the venue please <a href='https://ainmhicon.ie/#pricing' target='_blank' className="link">Click Here</a></p>
-            <Link href='https://www.claytonhotels.com/liffey-valley/' target='_blank' className='btn mt-2'>Clayton Hotel Liffey Valley Website</Link>
+            <p>For more information about staying at the venue please <a href='https://ainmhicon.ie/pricing' target='_blank' className="link">Click Here</a></p>
+            <Link href='https://www.claytonhotels.com/liffey-valley/' target='_blank' className='btn mt-2 btn-secondary rounded-md'>Clayton Hotel Liffey Valley Website</Link>
             <p>Use the promo code "<b>LOYAL</b>" when completing your booking! This will give a small discount on flexible room rates.</p>
 
-            <button type="button" onClick={navigateBack} className="btn btn-neutral mt-4 w-full">Back to Dashboard</button>
+            <button type="button" onClick={navigateBack} className="btn btn-neutral mt-18 w-full rounded-md">Back to Dashboard</button>
         </>
     )
 }

--- a/app/reg/page.tsx
+++ b/app/reg/page.tsx
@@ -9,7 +9,6 @@ import { getSelectedProduct, handleCheckout } from "../utils/public/stripe";
 import { useAuth } from "../context/authContext";
 import Loading from "../components/loading";
 import { days } from "../utils/day-mapping";
-import { getActiveCheckoutSession } from "../utils/private/supabase";
 
 const regStartTime = Number(process.env.NEXT_PUBLIC_REG_START_TIME)
 const regEndTime = Number(process.env.NEXT_PUBLIC_REG_END_TIME)
@@ -32,23 +31,25 @@ export default function RegPageForm() {
     const [loading, setLoading] = useState(true)
     const router = useRouter()
     const { user, attendee } = useAuth()
-
+    const [currentStep, setCurrentStep] = useState(window.location.hash === '#confirmation' ? 3 : 0)
     useEffect(() => {
         const load = async () => {
-            setLoading(true)
-            if(!user) { return }
-            if(!(await resumeCheckoutSession(user.id))) {
-               const ticketData = await getTicketStock()
-               setTicketData(ticketData)
+            if (!user) { return }
+            if (!(await resumeCheckoutSession(user.id))) {
+                const ticketData = await getTicketStock()
+                setTicketData(ticketData)
+                setLoading(false)
             }
+        }
+        if (currentStep !== 3) {
+            load()
+        } else {
             setLoading(false)
         }
-        load()
-        
+
     }, [user])
 
 
-    const [currentStep, setCurrentStep] = useState(window.location.hash === '#confirmation' ? 3 : 0)
     const [day, setDay] = useState<AttendanceDay | null>(null)
     const [tier, setTier] = useState<Tier | null>(null)
     const [loadingPayment, setLoadingPayment] = useState(false)
@@ -92,23 +93,79 @@ export default function RegPageForm() {
     // Confetti effect for success step
     useEffect(() => {
         if (currentStep !== STEPS.CONFIRMATION) return
-
-        var count = 200;
+        var count = 400;
         var defaults = {
             origin: { y: 0.7 }
         };
 
-        function fire(particleRatio: number, opts: { spread: number, startVelocity?: number, decay?: number, scalar?: number }) {
+        // TODO: Replace these with the leaf shapes from the leaf drawing branch when its ready.
+        const oakLeaf = confetti.shapeFromPath({
+            path: `M250 30
+C190 90 165 180 170 285
+C175 395 205 495 250 570
+C295 495 325 395 330 285
+C335 180 310 90 250 30
+Z`
+        });
+        const leaf1 = confetti.shapeFromPath({
+            path: `M250 30
+C220 75 175 75 145 120
+C175 145 115 205 55 220
+C125 260 95 330 45 375
+C120 390 155 465 130 520
+C190 510 225 550 250 570
+C275 550 310 510 370 520
+C345 465 380 390 455 375
+C405 330 375 260 445 220
+C385 205 325 145 355 120
+C325 75 280 75 250 30
+Z`
+        });
+        const leaf2 = confetti.shapeFromPath({
+            path: `M250 40
+C205 95 185 170 170 255
+C120 235 70 250 35 290
+C80 315 120 340 170 360
+C120 390 85 435 70 520
+C145 495 205 455 250 415
+C295 455 355 495 430 520
+C415 435 380 390 330 360
+C380 340 420 315 465 290
+C430 250 380 235 330 255
+C315 170 295 95 250 40
+Z`
+        });
+        const leaf3 = confetti.shapeFromPath({
+            path: `M250 30
+C145 45 55 145 65 285
+C75 425 155 520 250 570
+C345 520 425 425 435 285
+C445 145 355 45 250 30
+Z`
+        });
+
+        function fire(particleRatio: number, opts: { spread: number, startVelocity?: number, decay?: number, scalar?: number, drift?: number, ticks?: number }) {
             confetti({
                 ...defaults,
                 ...opts,
-                particleCount: Math.floor(count * particleRatio)
+                particleCount: Math.floor(count * particleRatio),
+                shapes: [oakLeaf, leaf1, leaf2, leaf3],
+                colors: [
+                    "#4F772D",
+                    "#8A9A3B",
+                    "#C97A2B",
+                    "#A63D2F",
+                    "#C9A227",
+                ],
+                scalar: 3
             });
         }
 
         fire(0.25, {
             spread: 26,
             startVelocity: 55,
+            drift: 0.7,
+            ticks: 100
         });
         fire(0.2, {
             spread: 60,
@@ -116,17 +173,26 @@ export default function RegPageForm() {
         fire(0.35, {
             spread: 100,
             decay: 0.91,
-            scalar: 0.8
+            drift: 2.1,
+            ticks: 200
+        });
+        fire(0.35, {
+            spread: 100,
+            decay: 0.91,
+            drift: -2.1,
+            ticks: 200
         });
         fire(0.1, {
             spread: 120,
             startVelocity: 25,
             decay: 0.92,
-            scalar: 1.2
+            drift: -0.7,
         });
         fire(0.1, {
             spread: 120,
             startVelocity: 45,
+            drift: 0.4,
+            ticks: 250
         });
     }, [currentStep])
 
@@ -313,7 +379,7 @@ export default function RegPageForm() {
                                                 In the meantime, you can update your details whenever you like from the dashboard
                                             </p>
                                             <button
-                                                className='btn btn-primary'
+                                                className='btn btn-secondary rounded-md'
                                                 onClick={() => router.push('/dashboard')}
                                             >
                                                 Return to dashboard
@@ -336,7 +402,7 @@ export default function RegPageForm() {
                 </div>
                 <button className="btn btn-sm btn-secondary bg-white text-error border-0 rounded-3xl" onClick={() => setCheckoutError(false)}>Okay</button>
             </div>
-            
+
         </AuthWrapper>
     )
 }

--- a/app/reg/page.tsx
+++ b/app/reg/page.tsx
@@ -7,12 +7,14 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { getSelectedProduct, handleCheckout } from "../utils/public/stripe";
 import { useAuth } from "../context/authContext";
+import Loading from "../components/loading";
+import { days } from "../utils/day-mapping";
 
 const regStartTime = Number(process.env.NEXT_PUBLIC_REG_START_TIME)
 const regEndTime = Number(process.env.NEXT_PUBLIC_REG_END_TIME)
 
-type AttendanceDay = 'Saturday' | 'Sunday' | 'Weekend'
-type Tier = 'Standard' | 'Sponsor' | 'Founder'
+type AttendanceDay = 'Friday' | 'Saturday' | 'Sunday' | 'Full-Event'
+type Tier = 'Standard' | 'Sponsor' | 'Super-Sponsor'
 
 const soldOut = ' SOLD OUT'
 
@@ -23,25 +25,13 @@ const STEPS = {
     CONFIRMATION: 3
 }
 
-
 export default function RegPageForm() {
-    const [ticketData, setTicketData] = useState({ saturdayDisabled: false, sundayDisabled: false })
+    const [ticketData, setTicketData] = useState<Set<number>>(new Set())
+    const [checkoutError, setCheckoutError] = useState(false)
+    const [loading, setLoading] = useState(true)
     useEffect(() => {
-        const getData = async () => {
-            const data = await getTicketStock()
-
-            const ticketsSoldSat = parseInt(data.tickets_sold_sat)
-            const venueCapacitySat = parseInt(data.venue_capacity_sat)
-            const saturdayDisabled = ticketsSoldSat >= venueCapacitySat
-
-            const ticketsSoldSun = parseInt(data.tickets_sold_sun)
-            const venueCapacitySun = parseInt(data.venue_capacity_sun)
-            const sundayDisabled = ticketsSoldSun >= venueCapacitySun
-            setTicketData({ saturdayDisabled, sundayDisabled })
-        }
-        getData()
+        getTicketStock().then(t => setTicketData(t)).finally(() => setLoading(false))
     }, [])
-
 
     const router = useRouter()
     const { user, attendee } = useAuth()
@@ -51,16 +41,18 @@ export default function RegPageForm() {
     const [tier, setTier] = useState<Tier | null>(null)
     const [loadingPayment, setLoadingPayment] = useState(false)
 
-    const weekendDisabled = ticketData.saturdayDisabled || ticketData.sundayDisabled
+    const weekendDisabled = !([days.friday, days.saturday, days.sunday].every(d => ticketData.has(d)))
 
     function validateTicketStock(day: string): void {
         const soldOutError = new Error("Tickets are sold out for selected date(s)");
 
         switch (day) {
+            case 'Friday':
+                if (!ticketData.has(days.friday)) return
             case 'Saturday':
-                if (!ticketData.saturdayDisabled) return
+                if (!ticketData.has(days.saturday)) return
             case 'Sunday':
-                if (!ticketData.sundayDisabled) return
+                if (!ticketData.has(days.sunday)) return
             case 'Weekend':
             default:
                 if (!weekendDisabled) return
@@ -152,7 +144,7 @@ export default function RegPageForm() {
                             if (index === 0) goToAttendance()
                             if (index === 1) goToTier()
                         }}
-                        className={`step ${currentStep >= index ? 'step-primary' : ''
+                        className={`step step-neutral ${currentStep >= index ? 'step-secondary' : ''
                             } ${((index === 0 && (currentStep === 1 || currentStep === 2)) ||
                                 (index === 1 && currentStep === 2)) ? 'cursor-pointer' : ''
                             }`}
@@ -170,144 +162,170 @@ export default function RegPageForm() {
                         className="flex w-full h-full transition-transform duration-500 ease-in-out"
                         style={{ transform: `translateX(-${currentStep * 100}%)` }}
                     >
-                        {/* Step 1: Attendance */}
-                        <div className="min-w-full w-full flex-shrink-0 p-2">
-                            <div>
-                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Attendance Days</h2>
-                                <div className="space-y-4">
-                                    <button
-                                        onClick={(e) => {
-                                            setDay('Weekend' as AttendanceDay);
-                                            setCurrentStep(STEPS.TIER);
-                                        }}
-                                        className={`btn btn-neutral w-full ${day === 'Weekend' && 'btn-primary'}`}
-                                        disabled={weekendDisabled}
-                                    >
-                                        Full Weekend, 11th-12th April 2026
-                                        {(weekendDisabled) && soldOut}
-                                    </button>
-                                    <button
-                                        onClick={(e) => {
-                                            setDay('Saturday' as AttendanceDay);
-                                            setCurrentStep(STEPS.TIER);
-                                        }}
-                                        className={`btn btn-neutral w-full ${day === 'Saturday' && 'btn-primary'}`}
-                                        disabled={ticketData.saturdayDisabled}
-                                    >
-                                        Saturday, 11th April 2026
-                                        {ticketData.saturdayDisabled && soldOut}
-                                    </button>
-                                    <button
-                                        onClick={(e) => {
-                                            setDay('Sunday' as AttendanceDay);
-                                            setCurrentStep(STEPS.TIER);
-                                        }}
-                                        className={`btn btn-neutral w-full ${day === 'Sunday' && 'btn-primary'}`}
-                                        disabled={ticketData.sundayDisabled}
-                                    >
-                                        Sunday, 12th April 2026
-                                        {ticketData.sundayDisabled && soldOut}
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
+                        {loading ? <Loading /> :
+                            (
+                                <>
+                                    {/* Step 1: Attendance */}
+                                    <div className="min-w-full w-full flex-shrink-0 p-2">
+                                        <div>
+                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Attendance Days</h2>
+                                            <div className="space-y-4">
+                                                <button
+                                                    onClick={(e) => {
+                                                        setDay('Full-Event' as AttendanceDay);
+                                                        setCurrentStep(STEPS.TIER);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${day === 'Full-Event' && 'btn-secondary'}`}
+                                                    disabled={weekendDisabled}
+                                                >
+                                                    <span>Full-Event, 2<sup>nd</sup> - 4<sup>th</sup> April 2027</span>
+                                                    {(weekendDisabled) && soldOut}
+                                                </button>
+                                                <button
+                                                    onClick={() => {
+                                                        setDay('Friday' as AttendanceDay);
+                                                        setCurrentStep(STEPS.TIER);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${day === 'Friday' && 'btn-secondary'}`}
+                                                    disabled={!ticketData.has(days.friday)}
+                                                >
+                                                    <span>Friday, 4<sup>th</sup> April 2027</span>
+                                                    {!ticketData.has(days.friday) && soldOut}
+                                                </button>
+                                                <button
+                                                    onClick={() => {
+                                                        setDay('Saturday' as AttendanceDay);
+                                                        setCurrentStep(STEPS.TIER);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${day === 'Saturday' && 'btn-secondary'}`}
+                                                    disabled={!ticketData.has(days.saturday)}
+                                                >
+                                                    <span>Saturday, 5<sup>th</sup> April 2027</span>
+                                                    {!ticketData.has(days.saturday) && soldOut}
+                                                </button>
+                                                <button
+                                                    onClick={() => {
+                                                        setDay('Sunday' as AttendanceDay);
+                                                        setCurrentStep(STEPS.TIER);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${day === 'Sunday' && 'btn-secondary'}`}
+                                                    disabled={!ticketData.has(days.sunday)}
+                                                >
+                                                    <span>Sunday, 6<sup>th</sup> April 2027</span>
+                                                    {!ticketData.has(days.sunday) && soldOut}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
 
-                        {/* Step 2: Tier */}
-                        <div className="min-w-full w-full flex-shrink-0 p-2">
-                            <div>
-                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Tier</h2>
-                                <div className="space-y-4">
-                                    <button
-                                        onClick={() => {
-                                            setTier('Standard' as Tier);
-                                            setCurrentStep(STEPS.PAYMENT);
-                                        }}
-                                        className={`btn btn-neutral w-full ${tier === 'Standard' && 'btn-primary'}`}
-                                    >
-                                        Standard
-                                    </button>
-                                    <button
-                                        onClick={() => {
-                                            setTier('Sponsor' as Tier);
-                                            setCurrentStep(STEPS.PAYMENT);
-                                        }}
-                                        className={`btn btn-neutral w-full ${tier === 'Sponsor' && 'btn-primary'}`}
-                                        disabled={true}
-                                    >
-                                        Sponsor SOLD OUT
-                                    </button>
-                                    {day === 'Weekend' && (
-                                        <button
-                                            onClick={() => {
-                                                setTier('Founder' as Tier);
-                                                setCurrentStep(STEPS.PAYMENT);
-                                            }}
-                                            className={`btn btn-neutral w-full ${tier === 'Founder' && 'btn-primary'}`}
-                                            disabled={true}
-                                        >
-                                            Founder SOLD OUT
-                                        </button>
-                                    )}
-                                </div>
-                            </div>
-                        </div>
+                                    {/* Step 2: Tier */}
+                                    <div className="min-w-full w-full flex-shrink-0 p-2">
+                                        <div>
+                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Tier</h2>
+                                            <div className="space-y-4">
+                                                <button
+                                                    onClick={() => {
+                                                        setTier('Standard' as Tier);
+                                                        setCurrentStep(STEPS.PAYMENT);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${tier === 'Standard' && 'btn-secondary'}`}
+                                                >
+                                                    Standard
+                                                </button>
+                                                <button
+                                                    onClick={() => {
+                                                        setTier('Sponsor' as Tier);
+                                                        setCurrentStep(STEPS.PAYMENT);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${tier === 'Sponsor' && 'btn-secondary'}`}
+                                                >
+                                                    Sponsor
+                                                </button>
+                                                <button
+                                                    onClick={() => {
+                                                        setTier('Super-Sponsor' as Tier);
+                                                        setCurrentStep(STEPS.PAYMENT);
+                                                    }}
+                                                    className={`btn btn-neutral w-full ${tier === 'Super-Sponsor' && 'btn-secondary'}`}
+                                                    disabled={day !== 'Full-Event'}
+                                                >
+                                                    Super-Sponsor {day !== 'Full-Event' && '(Available with Full-Event tickets)'}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
 
-                        {/* Step 3: Payment */}
-                        <div className="min-w-full  w-full flex-shrink-0 p-2">
-                            <div>
-                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Pay for your ticket</h2>
-                                <p className="mb-6">To secure your <b>{day} {tier}</b> ticket please click below to pay securely via Stripe</p>
-                                <button
-                                    onClick={async () => {
-                                        if (!day || !tier) return;
+                                    {/* Step 3: Payment */}
+                                    <div className="min-w-full  w-full flex-shrink-0 p-2">
+                                        <div>
+                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Pay for your ticket</h2>
+                                            <p className="mb-6">To secure your <b>{day} {tier}</b> ticket please click below to pay securely via Stripe</p>
+                                            <button
+                                                onClick={async () => {
+                                                    if (!day || !tier) return;
 
-                                        setLoadingPayment(true);
+                                                    setLoadingPayment(true);
 
-                                        try {
-                                            const res = await getSelectedProduct(day, tier);
-                                            const productData = await res.json();
+                                                    try {
+                                                        const res = await getSelectedProduct(day, tier);
+                                                        const productData = await res.json();
 
-                                            validateTicketStock(day)
+                                                        validateTicketStock(day)
 
-                                            if (user) {
-                                                await handleCheckout(user.id, productData.default_price, day);
-                                            }
-                                        } catch (e) {
-                                            console.error(e);
-                                            setLoadingPayment(false);
-                                        }
-                                    }}
-                                    className="btn btn-neutral w-full"
-                                    disabled={loadingPayment}
-                                >
-                                    {loadingPayment && <span className="loading loading-ring loading-md mr-2"></span>}
-                                    {loadingPayment ? 'Processing...' : 'Pay now'}
-                                </button>
-                            </div>
-                        </div>
+                                                        if (user) {
+                                                            await handleCheckout(user.id, productData.default_price, day);
+                                                        }
+                                                    } catch (e) {
+                                                        console.error(e);
+                                                        setLoadingPayment(false);
+                                                        setCheckoutError(true)
 
-                        {/* Step 4: Confirmation */}
-                        <div className="min-w-full w-full flex-shrink-0 p-2">
-                            <div className="text-center">
-                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-4'>
-                                    You're going to Ainmhícon!
-                                </h2>
-                                <p className='mb-6'>
-                                    Thank you, we've received your payment! We'll be in touch with more details soon.
-                                    In the meantime, you can update your details whenever you like from the dashboard
-                                </p>
-                                <button
-                                    className='btn btn-primary'
-                                    onClick={() => router.push('/dashboard')}
-                                >
-                                    Return to dashboard
-                                </button>
-                            </div>
-                        </div>
+                                                    }
+                                                }}
+                                                className="btn btn-neutral w-full"
+                                                disabled={loadingPayment}
+                                            >
+                                                {loadingPayment && <span className="loading loading-ring loading-md mr-2"></span>}
+                                                {loadingPayment ? 'Processing...' : 'Pay now'}
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    {/* Step 4: Confirmation */}
+                                    <div className="min-w-full w-full flex-shrink-0 p-2">
+                                        <div className="text-center">
+                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-4'>
+                                                You're going to Ainmhícon!
+                                            </h2>
+                                            <p className='mb-6'>
+                                                Thank you, we've received your payment! We'll be in touch with more details soon.
+                                                In the meantime, you can update your details whenever you like from the dashboard
+                                            </p>
+                                            <button
+                                                className='btn btn-primary'
+                                                onClick={() => router.push('/dashboard')}
+                                            >
+                                                Return to dashboard
+                                            </button>
+                                        </div>
+                                    </div>
+                                </>
+                            )}
                     </div>
                 </div>
                 {<button className={`btn btn-circle w-[2rem] h-[2rem] btn-neutral mt-[53px] opacity-${canForwardStep() ? '100' : '0'} transition-all duration-200`} onClick={() => { if (canForwardStep()) { setCurrentStep(currentStep + 1) } }}>&gt;</button>}
             </div>
+            <div role={checkoutError ? "alert" : 'presentation'} className={`alert alert-error alert-vertical sm:alert-horizontal fixed bottom-4 left-1/2 transform -translate-x-1/2 transition-all duration-500 ease-in-out text-[#fff] ${checkoutError ? 'translate-y-0 opacity-100' : 'translate-y-20 opacity-0 pointer-events-none'}`}>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current h-6 w-6 shrink-0">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+                <div>
+                    <h3 className="font-bold">Checkout Error</h3>
+                    <div className="text-xs">Sorry, there was an error checking out. Please try again later.</div>
+                </div>
+                <button className="btn btn-sm btn-secondary bg-white text-error border-0 rounded-3xl" onClick={() => setCheckoutError(false)}>Okay</button>
+            </div>
+            
         </AuthWrapper>
     )
 }

--- a/app/reg/page.tsx
+++ b/app/reg/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { getTicketStock as getTicketStock } from "../utils/public/stripe";
+import { getTicketStock as getTicketStock, resumeCheckoutSession } from "../utils/public/stripe";
 import { AuthWrapper } from "@/app/components/authWrapper";
 import confetti from "canvas-confetti";
 import { useRouter } from "next/navigation";
@@ -9,6 +9,7 @@ import { getSelectedProduct, handleCheckout } from "../utils/public/stripe";
 import { useAuth } from "../context/authContext";
 import Loading from "../components/loading";
 import { days } from "../utils/day-mapping";
+import { getActiveCheckoutSession } from "../utils/private/supabase";
 
 const regStartTime = Number(process.env.NEXT_PUBLIC_REG_START_TIME)
 const regEndTime = Number(process.env.NEXT_PUBLIC_REG_END_TIME)
@@ -29,12 +30,23 @@ export default function RegPageForm() {
     const [ticketData, setTicketData] = useState<Set<number>>(new Set())
     const [checkoutError, setCheckoutError] = useState(false)
     const [loading, setLoading] = useState(true)
-    useEffect(() => {
-        getTicketStock().then(t => setTicketData(t)).finally(() => setLoading(false))
-    }, [])
-
     const router = useRouter()
     const { user, attendee } = useAuth()
+
+    useEffect(() => {
+        const load = async () => {
+            setLoading(true)
+            if(!user) { return }
+            if(!(await resumeCheckoutSession(user.id))) {
+               const ticketData = await getTicketStock()
+               setTicketData(ticketData)
+            }
+            setLoading(false)
+        }
+        load()
+        
+    }, [user])
+
 
     const [currentStep, setCurrentStep] = useState(window.location.hash === '#confirmation' ? 3 : 0)
     const [day, setDay] = useState<AttendanceDay | null>(null)
@@ -282,11 +294,10 @@ export default function RegPageForm() {
 
                                                     }
                                                 }}
-                                                className="btn btn-neutral w-full"
+                                                className="btn btn-neutral w-full max-w-94"
                                                 disabled={loadingPayment}
                                             >
-                                                {loadingPayment && <span className="loading loading-ring loading-md mr-2"></span>}
-                                                {loadingPayment ? 'Processing...' : 'Pay now'}
+                                                {loadingPayment ? (<span className="loading loading-ring loading-sm mr-2"></span>) : (<span>Pay now</span>)}
                                             </button>
                                         </div>
                                     </div>

--- a/app/reg/page.tsx
+++ b/app/reg/page.tsx
@@ -1,37 +1,20 @@
 "use client"
 
-import { getTicketStock as getTicketStock, resumeCheckoutSession } from "../utils/public/stripe";
-import { AuthWrapper } from "@/app/components/authWrapper";
-import confetti from "canvas-confetti";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { getSelectedProduct, handleCheckout } from "../utils/public/stripe";
-import { useAuth } from "../context/authContext";
-import Loading from "../components/loading";
-import { days } from "../utils/day-mapping";
+import { useRouter } from 'next/navigation'
+import { useAuth } from '../context/authContext'
+import { AuthWrapper } from '../components/authWrapper'
+import { RegView } from './view'
+import { useEffect, useState } from 'react'
+import { getTicketStock, resumeCheckoutSession } from '../utils/public/stripe'
+import Loading from '../components/loading'
 
-const regStartTime = Number(process.env.NEXT_PUBLIC_REG_START_TIME)
-const regEndTime = Number(process.env.NEXT_PUBLIC_REG_END_TIME)
-
-type AttendanceDay = 'Friday' | 'Saturday' | 'Sunday' | 'Full-Event'
-type Tier = 'Standard' | 'Sponsor' | 'Super-Sponsor'
-
-const soldOut = ' SOLD OUT'
-
-const STEPS = {
-    ATTENDANCE: 0,
-    TIER: 1,
-    PAYMENT: 2,
-    CONFIRMATION: 3
-}
-
-export default function RegPageForm() {
-    const [ticketData, setTicketData] = useState<Set<number>>(new Set())
-    const [checkoutError, setCheckoutError] = useState(false)
-    const [loading, setLoading] = useState(true)
-    const router = useRouter()
+export default function UserDetailsPage() {
     const { user, attendee } = useAuth()
-    const [currentStep, setCurrentStep] = useState(window.location.hash === '#confirmation' ? 3 : 0)
+    const router = useRouter()
+    const redirect = () => router.push('/dashboard')
+    const [ticketData, setTicketData] = useState<Set<number>>(new Set())
+    const [loading, setLoading] = useState(true)
+    const step = window.location.hash === '#confirmation' ? 3 : 0
     useEffect(() => {
         const load = async () => {
             if (!user) { return }
@@ -41,7 +24,7 @@ export default function RegPageForm() {
                 setLoading(false)
             }
         }
-        if (currentStep !== 3) {
+        if (step !== 3) {
             load()
         } else {
             setLoading(false)
@@ -49,360 +32,13 @@ export default function RegPageForm() {
 
     }, [user])
 
-
-    const [day, setDay] = useState<AttendanceDay | null>(null)
-    const [tier, setTier] = useState<Tier | null>(null)
-    const [loadingPayment, setLoadingPayment] = useState(false)
-
-    const weekendDisabled = !([days.friday, days.saturday, days.sunday].every(d => ticketData.has(d)))
-
-    function validateTicketStock(day: string): void {
-        const soldOutError = new Error("Tickets are sold out for selected date(s)");
-
-        switch (day) {
-            case 'Friday':
-                if (!ticketData.has(days.friday)) return
-            case 'Saturday':
-                if (!ticketData.has(days.saturday)) return
-            case 'Sunday':
-                if (!ticketData.has(days.sunday)) return
-            case 'Weekend':
-            default:
-                if (!weekendDisabled) return
-        }
-        throw soldOutError;
-    }
-
-    function canBackStep() {
-        return currentStep > 0 && currentStep < 3
-    }
-
-    function canForwardStep() {
-        if (currentStep === 0) { return day !== null }
-        if (currentStep === 1) { return tier !== null }
-        return false
-    }
-
-    const overrideTimer = new URL(window.location.href).searchParams.has('noTimer')
-    // Redirect to dashboard if attendee info not complete
-    useEffect(() => {
-        if (!attendee?.first_name || !attendee.last_name || !attendee.dob || (!overrideTimer && Date.now() < regStartTime) || Date.now() > regEndTime) {
-            router.push('/dashboard')
-        }
-    }, [attendee])
-    // Confetti effect for success step
-    useEffect(() => {
-        if (currentStep !== STEPS.CONFIRMATION) return
-        var count = 400;
-        var defaults = {
-            origin: { y: 0.7 }
-        };
-
-        // TODO: Replace these with the leaf shapes from the leaf drawing branch when its ready.
-        const oakLeaf = confetti.shapeFromPath({
-            path: `M250 30
-C190 90 165 180 170 285
-C175 395 205 495 250 570
-C295 495 325 395 330 285
-C335 180 310 90 250 30
-Z`
-        });
-        const leaf1 = confetti.shapeFromPath({
-            path: `M250 30
-C220 75 175 75 145 120
-C175 145 115 205 55 220
-C125 260 95 330 45 375
-C120 390 155 465 130 520
-C190 510 225 550 250 570
-C275 550 310 510 370 520
-C345 465 380 390 455 375
-C405 330 375 260 445 220
-C385 205 325 145 355 120
-C325 75 280 75 250 30
-Z`
-        });
-        const leaf2 = confetti.shapeFromPath({
-            path: `M250 40
-C205 95 185 170 170 255
-C120 235 70 250 35 290
-C80 315 120 340 170 360
-C120 390 85 435 70 520
-C145 495 205 455 250 415
-C295 455 355 495 430 520
-C415 435 380 390 330 360
-C380 340 420 315 465 290
-C430 250 380 235 330 255
-C315 170 295 95 250 40
-Z`
-        });
-        const leaf3 = confetti.shapeFromPath({
-            path: `M250 30
-C145 45 55 145 65 285
-C75 425 155 520 250 570
-C345 520 425 425 435 285
-C445 145 355 45 250 30
-Z`
-        });
-
-        function fire(particleRatio: number, opts: { spread: number, startVelocity?: number, decay?: number, scalar?: number, drift?: number, ticks?: number }) {
-            confetti({
-                ...defaults,
-                ...opts,
-                particleCount: Math.floor(count * particleRatio),
-                shapes: [oakLeaf, leaf1, leaf2, leaf3],
-                colors: [
-                    "#4F772D",
-                    "#8A9A3B",
-                    "#C97A2B",
-                    "#A63D2F",
-                    "#C9A227",
-                ],
-                scalar: 3
-            });
-        }
-
-        fire(0.25, {
-            spread: 26,
-            startVelocity: 55,
-            drift: 0.7,
-            ticks: 100
-        });
-        fire(0.2, {
-            spread: 60,
-        });
-        fire(0.35, {
-            spread: 100,
-            decay: 0.91,
-            drift: 2.1,
-            ticks: 200
-        });
-        fire(0.35, {
-            spread: 100,
-            decay: 0.91,
-            drift: -2.1,
-            ticks: 200
-        });
-        fire(0.1, {
-            spread: 120,
-            startVelocity: 25,
-            decay: 0.92,
-            drift: -0.7,
-        });
-        fire(0.1, {
-            spread: 120,
-            startVelocity: 45,
-            drift: 0.4,
-            ticks: 250
-        });
-    }, [currentStep])
-
-    const goToAttendance = () => {
-        if (currentStep > STEPS.ATTENDANCE && currentStep !== STEPS.CONFIRMATION) {
-            setCurrentStep(STEPS.ATTENDANCE)
-            setTier(null)
-        }
-    }
-
-    const goToTier = () => {
-        if (currentStep > STEPS.TIER && currentStep !== STEPS.CONFIRMATION && day) {
-            setCurrentStep(STEPS.TIER)
-        }
-    }
-
-    const stepTitles = ['Attendance', 'Ticket Tier', 'Payment', 'Confirmation']
-
     return (
-        <AuthWrapper>
-            {/* Progress Bar */}
-            <ul className="steps w-full mb-8">
-                {stepTitles.map((title, index) => (
-                    <li
-                        key={index}
-                        onClick={() => {
-                            if (index === 0) goToAttendance()
-                            if (index === 1) goToTier()
-                        }}
-                        className={`step step-neutral ${currentStep >= index ? 'step-secondary' : ''
-                            } ${((index === 0 && (currentStep === 1 || currentStep === 2)) ||
-                                (index === 1 && currentStep === 2)) ? 'cursor-pointer' : ''
-                            }`}
-                    >
-                        {title}
-                    </li>
-                ))}
-            </ul>
-
-            {/* Sliding Form Container */}
-            <div className="flex flex-row items-center justify-around">
-                {<button className={`btn btn-circle w-[2rem] h-[2rem] btn-neutral mt-[53px] opacity-${canBackStep() ? '100' : '0'} transition-all duration-200`} onClick={() => { if (canBackStep()) { setCurrentStep(currentStep - 1) } }}>&lt;</button>}
-                <div className="relative w-[75%] overflow-hidden mb-auto max-w-[80vw] ">
-                    <div
-                        className="flex w-full h-full transition-transform duration-500 ease-in-out"
-                        style={{ transform: `translateX(-${currentStep * 100}%)` }}
-                    >
-                        {loading ? <Loading /> :
-                            (
-                                <>
-                                    {/* Step 1: Attendance */}
-                                    <div className="min-w-full w-full flex-shrink-0 p-2">
-                                        <div>
-                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Attendance Days</h2>
-                                            <div className="space-y-4">
-                                                <button
-                                                    onClick={(e) => {
-                                                        setDay('Full-Event' as AttendanceDay);
-                                                        setCurrentStep(STEPS.TIER);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${day === 'Full-Event' && 'btn-secondary'}`}
-                                                    disabled={weekendDisabled}
-                                                >
-                                                    <span>Full-Event, 2<sup>nd</sup> - 4<sup>th</sup> April 2027</span>
-                                                    {(weekendDisabled) && soldOut}
-                                                </button>
-                                                <button
-                                                    onClick={() => {
-                                                        setDay('Friday' as AttendanceDay);
-                                                        setCurrentStep(STEPS.TIER);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${day === 'Friday' && 'btn-secondary'}`}
-                                                    disabled={!ticketData.has(days.friday)}
-                                                >
-                                                    <span>Friday, 4<sup>th</sup> April 2027</span>
-                                                    {!ticketData.has(days.friday) && soldOut}
-                                                </button>
-                                                <button
-                                                    onClick={() => {
-                                                        setDay('Saturday' as AttendanceDay);
-                                                        setCurrentStep(STEPS.TIER);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${day === 'Saturday' && 'btn-secondary'}`}
-                                                    disabled={!ticketData.has(days.saturday)}
-                                                >
-                                                    <span>Saturday, 5<sup>th</sup> April 2027</span>
-                                                    {!ticketData.has(days.saturday) && soldOut}
-                                                </button>
-                                                <button
-                                                    onClick={() => {
-                                                        setDay('Sunday' as AttendanceDay);
-                                                        setCurrentStep(STEPS.TIER);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${day === 'Sunday' && 'btn-secondary'}`}
-                                                    disabled={!ticketData.has(days.sunday)}
-                                                >
-                                                    <span>Sunday, 6<sup>th</sup> April 2027</span>
-                                                    {!ticketData.has(days.sunday) && soldOut}
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    {/* Step 2: Tier */}
-                                    <div className="min-w-full w-full flex-shrink-0 p-2">
-                                        <div>
-                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Tier</h2>
-                                            <div className="space-y-4">
-                                                <button
-                                                    onClick={() => {
-                                                        setTier('Standard' as Tier);
-                                                        setCurrentStep(STEPS.PAYMENT);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${tier === 'Standard' && 'btn-secondary'}`}
-                                                >
-                                                    Standard
-                                                </button>
-                                                <button
-                                                    onClick={() => {
-                                                        setTier('Sponsor' as Tier);
-                                                        setCurrentStep(STEPS.PAYMENT);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${tier === 'Sponsor' && 'btn-secondary'}`}
-                                                >
-                                                    Sponsor
-                                                </button>
-                                                <button
-                                                    onClick={() => {
-                                                        setTier('Super-Sponsor' as Tier);
-                                                        setCurrentStep(STEPS.PAYMENT);
-                                                    }}
-                                                    className={`btn btn-neutral w-full ${tier === 'Super-Sponsor' && 'btn-secondary'}`}
-                                                    disabled={day !== 'Full-Event'}
-                                                >
-                                                    Super-Sponsor {day !== 'Full-Event' && '(Available with Full-Event tickets)'}
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    {/* Step 3: Payment */}
-                                    <div className="min-w-full  w-full flex-shrink-0 p-2">
-                                        <div>
-                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Pay for your ticket</h2>
-                                            <p className="mb-6">To secure your <b>{day} {tier}</b> ticket please click below to pay securely via Stripe</p>
-                                            <button
-                                                onClick={async () => {
-                                                    if (!day || !tier) return;
-
-                                                    setLoadingPayment(true);
-
-                                                    try {
-                                                        const res = await getSelectedProduct(day, tier);
-                                                        const productData = await res.json();
-
-                                                        validateTicketStock(day)
-
-                                                        if (user) {
-                                                            await handleCheckout(user.id, productData.default_price, day);
-                                                        }
-                                                    } catch (e) {
-                                                        console.error(e);
-                                                        setLoadingPayment(false);
-                                                        setCheckoutError(true)
-
-                                                    }
-                                                }}
-                                                className="btn btn-neutral w-full max-w-94"
-                                                disabled={loadingPayment}
-                                            >
-                                                {loadingPayment ? (<span className="loading loading-ring loading-sm mr-2"></span>) : (<span>Pay now</span>)}
-                                            </button>
-                                        </div>
-                                    </div>
-
-                                    {/* Step 4: Confirmation */}
-                                    <div className="min-w-full w-full flex-shrink-0 p-2">
-                                        <div className="text-center">
-                                            <h2 className='font-[family-name:var(--font-sora)] text-xl mb-4'>
-                                                You're going to Ainmhícon!
-                                            </h2>
-                                            <p className='mb-6'>
-                                                Thank you, we've received your payment! We'll be in touch with more details soon.
-                                                In the meantime, you can update your details whenever you like from the dashboard
-                                            </p>
-                                            <button
-                                                className='btn btn-secondary rounded-md'
-                                                onClick={() => router.push('/dashboard')}
-                                            >
-                                                Return to dashboard
-                                            </button>
-                                        </div>
-                                    </div>
-                                </>
-                            )}
-                    </div>
-                </div>
-                {<button className={`btn btn-circle w-[2rem] h-[2rem] btn-neutral mt-[53px] opacity-${canForwardStep() ? '100' : '0'} transition-all duration-200`} onClick={() => { if (canForwardStep()) { setCurrentStep(currentStep + 1) } }}>&gt;</button>}
-            </div>
-            <div role={checkoutError ? "alert" : 'presentation'} className={`alert alert-error alert-vertical sm:alert-horizontal fixed bottom-4 left-1/2 transform -translate-x-1/2 transition-all duration-500 ease-in-out text-[#fff] ${checkoutError ? 'translate-y-0 opacity-100' : 'translate-y-20 opacity-0 pointer-events-none'}`}>
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current h-6 w-6 shrink-0">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                </svg>
-                <div>
-                    <h3 className="font-bold">Checkout Error</h3>
-                    <div className="text-xs">Sorry, there was an error checking out. Please try again later.</div>
-                </div>
-                <button className="btn btn-sm btn-secondary bg-white text-error border-0 rounded-3xl" onClick={() => setCheckoutError(false)}>Okay</button>
-            </div>
-
-        </AuthWrapper>
+        <AuthWrapper requireAuth={true} allowIncompleteProfile={true}>
+            {
+                loading
+                    ? <Loading />
+                    : <RegView user={user} attendee={attendee} onRedirect={redirect} startingStep={step} ticketData={ticketData} />
+            }
+        </AuthWrapper >
     )
 }

--- a/app/reg/view.tsx
+++ b/app/reg/view.tsx
@@ -1,0 +1,388 @@
+"use client"
+
+import confetti from "canvas-confetti";
+import { useEffect, useState } from "react";
+import { getSelectedProduct, handleCheckout } from "../utils/public/stripe";
+import { days } from "../utils/day-mapping";
+import { User } from "@supabase/supabase-js";
+import { Attendee } from "../utils/types";
+
+const regStartTime = Number(process.env.NEXT_PUBLIC_REG_START_TIME)
+const regEndTime = Number(process.env.NEXT_PUBLIC_REG_END_TIME)
+
+type AttendanceDay = 'Friday' | 'Saturday' | 'Sunday' | 'Full-Event'
+type Tier = 'Standard' | 'Sponsor' | 'Super-Sponsor'
+
+const soldOut = ' SOLD OUT'
+
+const STEPS = {
+    ATTENDANCE: 0,
+    TIER: 1,
+    PAYMENT: 2,
+    CONFIRMATION: 3
+}
+
+interface RegViewProps {
+    user: User | null
+    attendee: Attendee | null
+    onRedirect: () => void
+    startingStep?: number
+    ticketData: Set<number>
+}
+
+export function RegView({ user, attendee, startingStep, ticketData, onRedirect }: RegViewProps) {
+    const [checkoutError, setCheckoutError] = useState(false)
+    const [currentStep, setCurrentStep] = useState(startingStep || 0)
+
+
+    const [day, setDay] = useState<AttendanceDay | null>(null)
+    const [tier, setTier] = useState<Tier | null>(null)
+    const [loadingPayment, setLoadingPayment] = useState(false)
+
+    const weekendDisabled = !([days.friday, days.saturday, days.sunday].every(d => ticketData.has(d)))
+
+    function validateTicketStock(day: string): void {
+        const soldOutError = new Error("Tickets are sold out for selected date(s)");
+
+        switch (day) {
+            case 'Friday':
+                if (!ticketData.has(days.friday)) return
+            case 'Saturday':
+                if (!ticketData.has(days.saturday)) return
+            case 'Sunday':
+                if (!ticketData.has(days.sunday)) return
+            case 'Weekend':
+            default:
+                if (!weekendDisabled) return
+        }
+        throw soldOutError;
+    }
+
+    function canBackStep() {
+        return currentStep > 0 && currentStep < 3
+    }
+
+    function canForwardStep() {
+        if (currentStep === 0) { return day !== null }
+        if (currentStep === 1) { return tier !== null }
+        return false
+    }
+
+    const overrideTimer = new URL(window.location.href).searchParams.has('noTimer')
+    // Redirect to dashboard if attendee info not complete
+    useEffect(() => {
+        if (!attendee?.first_name || !attendee.last_name || !attendee.dob || (!overrideTimer && Date.now() < regStartTime) || Date.now() > regEndTime) {
+            onRedirect()
+        }
+    }, [attendee])
+    // Confetti effect for success step
+    useEffect(() => {
+        if (currentStep !== STEPS.CONFIRMATION) return
+        var count = 400;
+        var defaults = {
+            origin: { y: 0.7 }
+        };
+
+        // TODO: Replace these with the leaf shapes from the leaf drawing branch when its ready.
+        const oakLeaf = confetti.shapeFromPath({
+            path: `M250 30
+C190 90 165 180 170 285
+C175 395 205 495 250 570
+C295 495 325 395 330 285
+C335 180 310 90 250 30
+Z`
+        });
+        const leaf1 = confetti.shapeFromPath({
+            path: `M250 30
+C220 75 175 75 145 120
+C175 145 115 205 55 220
+C125 260 95 330 45 375
+C120 390 155 465 130 520
+C190 510 225 550 250 570
+C275 550 310 510 370 520
+C345 465 380 390 455 375
+C405 330 375 260 445 220
+C385 205 325 145 355 120
+C325 75 280 75 250 30
+Z`
+        });
+        const leaf2 = confetti.shapeFromPath({
+            path: `M250 40
+C205 95 185 170 170 255
+C120 235 70 250 35 290
+C80 315 120 340 170 360
+C120 390 85 435 70 520
+C145 495 205 455 250 415
+C295 455 355 495 430 520
+C415 435 380 390 330 360
+C380 340 420 315 465 290
+C430 250 380 235 330 255
+C315 170 295 95 250 40
+Z`
+        });
+        const leaf3 = confetti.shapeFromPath({
+            path: `M250 30
+C145 45 55 145 65 285
+C75 425 155 520 250 570
+C345 520 425 425 435 285
+C445 145 355 45 250 30
+Z`
+        });
+
+        function fire(particleRatio: number, opts: { spread: number, startVelocity?: number, decay?: number, scalar?: number, drift?: number, ticks?: number }) {
+            confetti({
+                ...defaults,
+                ...opts,
+                particleCount: Math.floor(count * particleRatio),
+                shapes: [oakLeaf, leaf1, leaf2, leaf3],
+                colors: [
+                    "#4F772D",
+                    "#8A9A3B",
+                    "#C97A2B",
+                    "#A63D2F",
+                    "#C9A227",
+                ],
+                scalar: 3
+            });
+        }
+
+        fire(0.25, {
+            spread: 26,
+            startVelocity: 55,
+            drift: 0.7,
+            ticks: 100
+        });
+        fire(0.2, {
+            spread: 60,
+        });
+        fire(0.35, {
+            spread: 100,
+            decay: 0.91,
+            drift: 2.1,
+            ticks: 200
+        });
+        fire(0.35, {
+            spread: 100,
+            decay: 0.91,
+            drift: -2.1,
+            ticks: 200
+        });
+        fire(0.1, {
+            spread: 120,
+            startVelocity: 25,
+            decay: 0.92,
+            drift: -0.7,
+        });
+        fire(0.1, {
+            spread: 120,
+            startVelocity: 45,
+            drift: 0.4,
+            ticks: 250
+        });
+    }, [currentStep])
+
+    const goToAttendance = () => {
+        if (currentStep > STEPS.ATTENDANCE && currentStep !== STEPS.CONFIRMATION) {
+            setCurrentStep(STEPS.ATTENDANCE)
+            setTier(null)
+        }
+    }
+
+    const goToTier = () => {
+        if (currentStep > STEPS.TIER && currentStep !== STEPS.CONFIRMATION && day) {
+            setCurrentStep(STEPS.TIER)
+        }
+    }
+
+    const stepTitles = ['Attendance', 'Ticket Tier', 'Payment', 'Confirmation']
+
+    return (
+        <>
+            {/* Progress Bar */}
+            <ul className="steps w-full mb-8">
+                {stepTitles.map((title, index) => (
+                    <li
+                        key={index}
+                        onClick={() => {
+                            if (index === 0) goToAttendance()
+                            if (index === 1) goToTier()
+                        }}
+                        className={`step step-neutral ${currentStep >= index ? 'step-secondary' : ''
+                            } ${((index === 0 && (currentStep === 1 || currentStep === 2)) ||
+                                (index === 1 && currentStep === 2)) ? 'cursor-pointer' : ''
+                            }`}
+                    >
+                        {title}
+                    </li>
+                ))}
+            </ul>
+
+            {/* Sliding Form Container */}
+            <div className="flex flex-row items-center justify-around">
+                {<button className={`btn btn-circle w-[2rem] h-[2rem] btn-neutral mt-[53px] opacity-${canBackStep() ? '100' : '0'} transition-all duration-200`} onClick={() => { if (canBackStep()) { setCurrentStep(currentStep - 1) } }}>&lt;</button>}
+                <div className="relative w-[75%] overflow-hidden mb-auto max-w-[80vw] ">
+                    <div
+                        className="flex w-full h-full transition-transform duration-500 ease-in-out"
+                        style={{ transform: `translateX(-${currentStep * 100}%)` }}
+                    >
+                        {/* Step 1: Attendance */}
+                        <div className="min-w-full w-full flex-shrink-0 p-2">
+                            <div>
+                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Attendance Days</h2>
+                                <div className="space-y-4">
+                                    <button
+                                        onClick={(e) => {
+                                            setDay('Full-Event' as AttendanceDay);
+                                            setCurrentStep(STEPS.TIER);
+                                        }}
+                                        className={`btn btn-neutral w-full ${day === 'Full-Event' && 'btn-secondary'}`}
+                                        disabled={weekendDisabled}
+                                    >
+                                        <span>Full-Event, 2<sup>nd</sup> - 4<sup>th</sup> April 2027</span>
+                                        {(weekendDisabled) && soldOut}
+                                    </button>
+                                    <button
+                                        onClick={() => {
+                                            setDay('Friday' as AttendanceDay);
+                                            setCurrentStep(STEPS.TIER);
+                                        }}
+                                        className={`btn btn-neutral w-full ${day === 'Friday' && 'btn-secondary'}`}
+                                        disabled={!ticketData.has(days.friday)}
+                                    >
+                                        <span>Friday, 4<sup>th</sup> April 2027</span>
+                                        {!ticketData.has(days.friday) && soldOut}
+                                    </button>
+                                    <button
+                                        onClick={() => {
+                                            setDay('Saturday' as AttendanceDay);
+                                            setCurrentStep(STEPS.TIER);
+                                        }}
+                                        className={`btn btn-neutral w-full ${day === 'Saturday' && 'btn-secondary'}`}
+                                        disabled={!ticketData.has(days.saturday)}
+                                    >
+                                        <span>Saturday, 5<sup>th</sup> April 2027</span>
+                                        {!ticketData.has(days.saturday) && soldOut}
+                                    </button>
+                                    <button
+                                        onClick={() => {
+                                            setDay('Sunday' as AttendanceDay);
+                                            setCurrentStep(STEPS.TIER);
+                                        }}
+                                        className={`btn btn-neutral w-full ${day === 'Sunday' && 'btn-secondary'}`}
+                                        disabled={!ticketData.has(days.sunday)}
+                                    >
+                                        <span>Sunday, 6<sup>th</sup> April 2027</span>
+                                        {!ticketData.has(days.sunday) && soldOut}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Step 2: Tier */}
+                        <div className="min-w-full w-full flex-shrink-0 p-2">
+                            <div>
+                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Choose your Tier</h2>
+                                <div className="space-y-4">
+                                    <button
+                                        onClick={() => {
+                                            setTier('Standard' as Tier);
+                                            setCurrentStep(STEPS.PAYMENT);
+                                        }}
+                                        className={`btn btn-neutral w-full ${tier === 'Standard' && 'btn-secondary'}`}
+                                    >
+                                        Standard
+                                    </button>
+                                    <button
+                                        onClick={() => {
+                                            setTier('Sponsor' as Tier);
+                                            setCurrentStep(STEPS.PAYMENT);
+                                        }}
+                                        className={`btn btn-neutral w-full ${tier === 'Sponsor' && 'btn-secondary'}`}
+                                    >
+                                        Sponsor
+                                    </button>
+                                    <button
+                                        onClick={() => {
+                                            setTier('Super-Sponsor' as Tier);
+                                            setCurrentStep(STEPS.PAYMENT);
+                                        }}
+                                        className={`btn btn-neutral w-full ${tier === 'Super-Sponsor' && 'btn-secondary'}`}
+                                        disabled={day !== 'Full-Event'}
+                                    >
+                                        Super-Sponsor {day !== 'Full-Event' && '(Available with Full-Event tickets)'}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Step 3: Payment */}
+                        <div className="min-w-full  w-full flex-shrink-0 p-2">
+                            <div>
+                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-6'>Pay for your ticket</h2>
+                                <p>To secure your <b>{day} {tier}</b> ticket please click to pay securely via Stripe</p>
+                                <p className="mb-6">You must complete checkout within <b>30 minutes</b>, or your ticket will be released and may no longer be available to purchase.</p>
+                                <button
+                                    onClick={async () => {
+                                        if (!day || !tier) return;
+
+                                        setLoadingPayment(true);
+
+                                        try {
+                                            const res = await getSelectedProduct(day, tier);
+                                            const productData = await res.json();
+
+                                            validateTicketStock(day)
+
+                                            if (user) {
+                                                await handleCheckout(user.id, productData.default_price, day);
+                                            }
+                                        } catch (e) {
+                                            console.error(e);
+                                            setLoadingPayment(false);
+                                            setCheckoutError(true)
+
+                                        }
+                                    }}
+                                    className="btn btn-neutral w-full max-w-94"
+                                    disabled={loadingPayment}
+                                >
+                                    {loadingPayment ? (<span className="loading loading-ring loading-sm mr-2"></span>) : (<span>Pay now</span>)}
+                                </button>
+                            </div>
+                        </div>
+
+                        {/* Step 4: Confirmation */}
+                        <div className="min-w-full w-full flex-shrink-0 p-2">
+                            <div className="text-center">
+                                <h2 className='font-[family-name:var(--font-sora)] text-xl mb-4'>
+                                    You're going to Ainmhícon!
+                                </h2>
+                                <p className='mb-6'>
+                                    Thank you, we've received your payment! We'll be in touch with more details soon.
+                                    In the meantime, you can update your details whenever you like from the dashboard
+                                </p>
+                                <button
+                                    className='btn btn-secondary rounded-md'
+                                    onClick={onRedirect}
+                                >
+                                    Return to dashboard
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {<button className={`btn btn-circle w-[2rem] h-[2rem] btn-neutral mt-[53px] opacity-${canForwardStep() ? '100' : '0'} transition-all duration-200`} onClick={() => { if (canForwardStep()) { setCurrentStep(currentStep + 1) } }}>&gt;</button>}
+            </div>
+            <div role={checkoutError ? "alert" : 'presentation'} className={`alert alert-error alert-vertical sm:alert-horizontal fixed bottom-4 left-1/2 transform -translate-x-1/2 transition-all duration-500 ease-in-out text-[#fff] ${checkoutError ? 'translate-y-0 opacity-100' : 'translate-y-20 opacity-0 pointer-events-none'}`}>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current h-6 w-6 shrink-0">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+                <div>
+                    <h3 className="font-bold">Checkout Error</h3>
+                    <div className="text-xs">Sorry, there was an error checking out. Please try again later.</div>
+                </div>
+                <button className="btn btn-sm btn-secondary bg-white text-error border-0 rounded-3xl" onClick={() => setCheckoutError(false)}>Okay</button>
+            </div>
+        </>
+    )
+}

--- a/app/user-details/avatar.tsx
+++ b/app/user-details/avatar.tsx
@@ -126,7 +126,7 @@ export default function Avatar({ userProfilePic, onImageChanged, updatesDisabled
                             e.preventDefault()
                             setCropping(false)
                         }}
-                        className="btn btn-error"
+                        className="btn btn-primary"
                     >
                         Cancel
                     </button>
@@ -135,7 +135,7 @@ export default function Avatar({ userProfilePic, onImageChanged, updatesDisabled
                             e.preventDefault()
                             finishCropping()
                         }}
-                        className="btn btn-primary"
+                        className="btn btn-secondary"
                     >
                         Save
                     </button>

--- a/app/user-details/avatar.tsx
+++ b/app/user-details/avatar.tsx
@@ -57,7 +57,7 @@ export default function Avatar({ userProfilePic, onImageChanged, updatesDisabled
                 >
                     {/* Image states */}
                     {!cropping && (<>
-                        {userProfilePic === 'loading' && <Loading />}
+                        {userProfilePic === 'loading' && <Loading className='h-full'/>}
                         {!userProfilePic && <div className="text-l w-[140px] h-[140px] flex justify-center items-center text-center">No Badge!</div>}
                         {userProfilePic && userProfilePic !== 'loading' && (
                             <img src={userProfilePic} className="aspect-square w-full h-full object-cover" />

--- a/app/user-details/view.tsx
+++ b/app/user-details/view.tsx
@@ -9,6 +9,7 @@ import { verifyAge } from "../utils/age-verification"
 
 const minimumConventionAge = Number(process.env.NEXT_PUBLIC_CON_MIN_AGE)
 const conventionDate = Number(process.env.NEXT_PUBLIC_CON_DATE)
+const supportEmail = process.env.NEXT_PUBLIC_SUPPORT_EMAIL
 
 interface UserDetailsViewProps {
     attendee: Attendee | null
@@ -140,7 +141,7 @@ export function UserDetailsView({ attendee, user, updateProfile, onRedirect, upd
                     <fieldset disabled={updatesDisabled}>
                         <form onSubmit={handleUpdate} >
                             <h2 className='font-[family-name:var(--font-sora)] text-xl mb-3'>Your Details</h2>
-                            {updatesDisabled && (<label className='block mb-4'>Changes to registration details are now closed! If there are details which need urgently updating please contact <a href='mailto:reg@ainmhicon.ie' className='underline text-info'>reg@ainmhicon.ie</a></label>)}
+                            {updatesDisabled && (<label className='block mb-4'>Changes to registration details are now closed! If there are details which need urgently updating please contact <a href={`mailto:${supportEmail}`} className='underline text-info'>{supportEmail}</a></label>)}
 
                             <Avatar userProfilePic={userProfilePic} onImageChanged={imageChangeHandler} updatesDisabled={updatesDisabled} />
                             <div className="divider">Legal Information</div>

--- a/app/user-details/view.tsx
+++ b/app/user-details/view.tsx
@@ -213,7 +213,7 @@ export function UserDetailsView({ attendee, user, updateProfile, onRedirect, upd
                             </textarea>
 
                             <ErrorMessage error={error} />
-                            {!updatesDisabled && <button type="submit" disabled={updatesDisabled} className="btn bg-base-100 text-base-content mt-4 w-full rounded-md">Update</button>}
+                            {!updatesDisabled && <button type="submit" disabled={updatesDisabled} className="btn btn-secondary mt-4 w-full rounded-md">Update</button>}
                         </form>
                     </fieldset>
                     <button type="button" onClick={navigateBack} className="btn btn-neutral w-full mt-3 rounded-md">{updatesDisabled ? 'Back': 'Cancel'}</button>

--- a/app/utils/day-mapping.ts
+++ b/app/utils/day-mapping.ts
@@ -1,0 +1,12 @@
+export const days = {
+    friday: 1,
+    saturday: 2,
+    sunday: 3
+}
+
+export function getDayValue(day: string) {
+    if(day in days) {
+        return days[day as keyof typeof days]
+    }
+    return -1
+}

--- a/app/utils/private/supabase.ts
+++ b/app/utils/private/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js"
+import { CURRENT_CON_ID } from "../constants"
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 
@@ -8,3 +9,66 @@ const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 if (!supabaseUrl || !supabaseServiceKey) { throw new Error('Missing supabase environment variables, ensure SUPABASE_URL and SUPABASE_SERVICE_KEY are set for this machine') }
 
 export const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+export async function getTicketAvailability() {
+    const { data, error } = await supabase
+        .from('tickets_remaining')
+        .select('day, remaining')
+        .eq('convention_id', CURRENT_CON_ID);
+
+    if (error) { throw error }
+    if (!data) {
+        return [];
+    }
+
+    return data
+        .filter(ticket => ticket.remaining > 0)
+        .map(ticket => ticket.day);
+}
+
+export async function removeTicketFromDays(selectedDay: number | null) {
+    await supabase.rpc('decrease_ticket_availability', {
+        p_convention_id: CURRENT_CON_ID,
+        p_day: selectedDay
+    })
+}
+
+export async function addTicketToDays(selectedDay: number | null) {
+    await supabase.rpc('increase_ticket_availability', {
+        p_convention_id: CURRENT_CON_ID,
+        p_day: selectedDay
+    })
+}
+
+export async function isUserRegistered(userId: string) {
+    return await supabase
+        .from('registrations')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('convention_id', CURRENT_CON_ID)
+        .maybeSingle()
+
+}
+
+export async function getActiveCheckoutSession(userId: string) {
+    const checkoutSession = await supabase
+        .from('open_checkout_sessions')
+        .select('stripe_session_id')
+        .eq('user_id', userId)
+        .maybeSingle()
+
+    return checkoutSession.data
+}
+
+export async function startUserCheckout(userId: string, stringSessionId: string) {
+    await supabase
+        .from('open_checkout_sessions')
+        .insert({user_id: userId, stripe_session_id: stringSessionId})
+}
+
+export async function clearUserCheckout(userId: string) {
+    await supabase
+        .from('open_checkout_sessions')
+        .delete()
+        .eq('user_id', userId)
+}

--- a/app/utils/public/stripe.ts
+++ b/app/utils/public/stripe.ts
@@ -19,7 +19,7 @@ export async function handleCheckout(userId: string, priceId: string, selectedDa
 }
 
 export async function getSelectedProduct(day: string, tier: string) {
-    const res = await fetch(`/api/get-selected-product?day=${encodeURIComponent(day)}&tier=${encodeURIComponent(tier)}`, {
+    const res = await fetch(`/api/get-selected-product?day=${encodeURIComponent(day.trim().toLowerCase())}&tier=${encodeURIComponent(tier.trim().toLowerCase())}`, {
         method: 'GET',
     })
 
@@ -32,7 +32,8 @@ export async function getTicketStock() {
     const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
     const res = await fetch(`${baseUrl}/api/get-ticket-stock`, { method: 'GET' })
 
-    if (res.status !== 200) { throw new Error(res.statusText) }
+    if (res.status !== 200) { return new Set<number>() }
 
-    return await res.json();
+    const daysInStock = await res.json()
+    return new Set<number>(daysInStock);
 }

--- a/app/utils/public/stripe.ts
+++ b/app/utils/public/stripe.ts
@@ -1,4 +1,5 @@
 import { loadStripe } from "@stripe/stripe-js";
+import { supabase } from "./supabase";
 
 const stripePublicKey = process.env.NEXT_PUBLIC_STRIPE_PK
 
@@ -36,4 +37,19 @@ export async function getTicketStock() {
 
     const daysInStock = await res.json()
     return new Set<number>(daysInStock);
+}
+
+export async function resumeCheckoutSession(userId: string) {
+    const {data, error} = await supabase
+            .from('open_checkout_sessions')
+            .select('stripe_session_id')
+            .eq('user_id', userId)
+            .maybeSingle()
+    
+    if(!error && typeof data?.stripe_session_id === 'string') {
+        const stripe = await stripePromise;
+        await stripe?.redirectToCheckout({ sessionId: data.stripe_session_id })
+        return true
+    }
+    return false
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ const isDev = process.env.NODE_ENV === 'development'
  
 const cspHeader = `
     default-src 'self' https://accounts.google.com/gsi/;
-    script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://accounts.google.com/gsi/client;
+    script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://accounts.google.com/gsi/client https://js.stripe.com;
     style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style;
     img-src 'self' blob: data: https://jxkruzcavimhseccupfu.supabase.co;
     font-src 'self';
@@ -14,6 +14,7 @@ const cspHeader = `
     form-action 'self';
     frame-ancestors 'none';
     upgrade-insecure-requests;
+    frame-src https://js.stripe.com/;
 `
 
 const nextConfig: NextConfig = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,7 @@ const cspHeader = `
     frame-ancestors 'none';
     upgrade-insecure-requests;
     frame-src https://js.stripe.com/;
+    worker-src blob:;
 `
 
 const nextConfig: NextConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@stripe/react-stripe-js": "^3.7.0",
         "@stripe/stripe-js": "^7.4.0",
         "@supabase/supabase-js": "^2.50.2",
-        "canvas-confetti": "^1.9.3",
+        "canvas-confetti": "^1.9.4",
         "moment": "^2.30.1",
         "next": "^15.5.7",
         "react": "^19.0.0",
@@ -3323,9 +3323,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvas-confetti": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
-      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
       "license": "ISC",
       "funding": {
         "type": "donate",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.4.0",
     "@supabase/supabase-js": "^2.50.2",
-    "canvas-confetti": "^1.9.3",
+    "canvas-confetti": "^1.9.4",
     "moment": "^2.30.1",
     "next": "^15.5.7",
     "react": "^19.0.0",

--- a/stories/dashboard.stories.tsx
+++ b/stories/dashboard.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const DefaultRegisteredState: Story = {
     args: {
+        user: defaultMockUser,
         attendee: defaultMockAttendee,
         registration: defaultRegistration,
         logout: () => { },
@@ -27,6 +28,7 @@ export const DefaultRegisteredState: Story = {
 
 export const DefaultUnregisteredState: Story = {
     args: {
+        user: defaultMockUser,
         attendee: defaultMockAttendee,
         registration: null,
         logout: () => { },
@@ -37,6 +39,7 @@ export const DefaultUnregisteredState: Story = {
 
 export const WithPreRegTimer: Story = {
     args: {
+        user: defaultMockUser,
         attendee: defaultMockAttendee,
         registration: null,
         logout: () => { },
@@ -47,6 +50,7 @@ export const WithPreRegTimer: Story = {
 
 export const WithRegEndingTimer: Story = {
     args: {
+        user: defaultMockUser,
         attendee: defaultMockAttendee,
         registration: null,
         logout: () => { },
@@ -57,6 +61,7 @@ export const WithRegEndingTimer: Story = {
 
 export const WithRegClosed: Story = {
     args: {
+        user: defaultMockUser,
         attendee: defaultMockAttendee,
         registration: null,
         logout: () => { },
@@ -68,6 +73,7 @@ export const WithRegClosed: Story = {
 
 export const WithBelowMinimumAgeUnregisteredState: Story = {
     args: {
+        user: defaultMockUser,
         attendee: { ...defaultMockAttendee, dob: new Date().toISOString() },
         registration: null,
         logout: () => { },

--- a/stories/reg.stories.tsx
+++ b/stories/reg.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { RegView } from '../app/reg/view'
+import { defaultMockAttendee, defaultMockUser } from './mocks/mock-types';
+
+const meta = {
+    title: 'reg',
+    component: RegView,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+    }
+} satisfies Meta<typeof RegView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StepOneSoldOut: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 0,
+        ticketData: new Set()
+    }
+};
+
+export const StepOneOneDayAvailable: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 0,
+        ticketData: new Set([1])
+    }
+};
+
+
+export const StepOneTwoDaysAvailable: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 0,
+        ticketData: new Set([1,2])
+    }
+};
+
+export const StepOneAllDaysAvailable: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 0,
+        ticketData: new Set([1,2,3])
+    }
+};
+
+export const StepTwo: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 1,
+        ticketData: new Set()
+    }
+};
+
+export const StepThree: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 2,
+        ticketData: new Set()
+    }
+};
+
+export const ConfirmationPage: Story = {
+    args: {
+        user: defaultMockUser,
+        attendee: defaultMockAttendee,
+        onRedirect: () => { },
+        startingStep: 3,
+        ticketData: new Set()
+    }
+};


### PR DESCRIPTION
This replaces our old stripe based ticket stock keeping with supabase. It also reserves tickets when the checkout starts and releases them when the checkout is not successful, which removes the chance for double selling tickets

Users can start 1 checkout session at a time. Flow is as follows

* User loads ticket selection - we check the tickets_remaining table for totals per day
* User selects available tickets and start checkout
* Backend reduces tickets_remaining by 1 for selected days and returns the checkout session
* Backend logs a new checkout session started for current user id and logs checkout session id
* On success, expiry or payment error stripe webhook clears the checkout session log from supabase
* On expiry or payment error stripe webhook increments available ticket